### PR TITLE
2.10.5 为什么用交叉熵代替二次代价函数 公式修订

### DIFF
--- a/ch02_机器学习基础/第二章_机器学习基础.md
+++ b/ch02_机器学习基础/第二章_机器学习基础.md
@@ -357,7 +357,7 @@ $$
 交叉熵函数权值$w$和偏置$b$的梯度推导为：
 
 $$
-\frac{\partial J}{\partial w_j}=\frac{1}{n}\sum_{x}(x_j\sigma{(z)}-y)\;，
+\frac{\partial J}{\partial w_j}=\frac{1}{n}\sum_{x}x_j(\sigma{(z)}-y)\;，
 \frac{\partial J}{\partial b}=\frac{1}{n}\sum_{x}(\sigma{(z)}-y)
 $$
 


### PR DESCRIPTION
2.10.5 为什么用交叉熵代替二次代价函数 公式修订
#299