### PR TITLE
加创造epub和pdf文件的脚本 added scripts for making epub and pdf files

### DIFF
--- a/make_epub.py
+++ b/make_epub.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import subprocess
+import glob
+
+title = '深度学习500问'
+directories = sorted(glob.glob('./ch*'))
+md_files = sorted(glob.glob('./ch*/第*.md'))
+resource_path = ':'.join(directories)
+input_files = ' '.join(['"' + x + '"' for x in md_files])
+
+subprocess.call('pandoc -t epub2 --webtex --metadata "title:' + title + '" --resource-path "' + resource_path + '" -o deeplearning.epub -i ' + input_files, shell=True)

--- a/make_epub3.py
+++ b/make_epub3.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import subprocess
+import glob
+
+title = '深度学习500问'
+directories = sorted(glob.glob('./ch*'))
+md_files = sorted(glob.glob('./ch*/第*.md'))
+resource_path = ':'.join(directories)
+input_files = ' '.join(['"' + x + '"' for x in md_files])
+
+subprocess.call('pandoc -t epub3 --metadata "title:' + title + '" --resource-path "' + resource_path + '" -o deeplearning.epub -i ' + input_files, shell=True)

--- a/make_pdf.py
+++ b/make_pdf.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import subprocess
+import glob
+
+title = '深度学习500问'
+directories = sorted(glob.glob('./ch*'))
+md_files = sorted(glob.glob('./ch*/第*.md'))
+resource_path = ':'.join(directories)
+input_files = ' '.join(['"' + x + '"' for x in md_files])
+
+subprocess.call('pandoc --pdf-engine=xelatex --metadata "title:' + title + '" --resource-path "' + resource_path + '" -o deeplearning.pdf -i ' + input_files, shell=True)


### PR DESCRIPTION
运行 `./make_epub.py` 就会在deeplearning.epub创造epub格式文件，此文件格式适合于在电子墨阅读器设备（例如kindle）上阅读

运行 `./make_pdf.py` 就会在deeplearning.pdf创造pdf格式文件

Run `./make_epub.py` to create an epub file at deeplearning.epub

Run `./make_pdf.py` to create a pdf file at deeplearning.pdf